### PR TITLE
해시태그 검색 페이지 구현

### DIFF
--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -15,7 +15,8 @@
             <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
                 <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
                     <li><a href="#" class="nav-link px-2 text-secondary">Home</a></li>
-                    <li><a href="#" class="nav-link px-2 text-white">mh-log</a></li>
+                    <li><a id="mhLog" href="#" class="nav-link px-2 text-white">mh-log</a></li>
+                    <li><a id="hashtag" href="#" class="nav-link px-2 text-white">HashTag</a></li>
                 </ul>
 
                 <div class="text-end">

--- a/src/main/resources/templates/common/header.th.xml
+++ b/src/main/resources/templates/common/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#mhLog" th:href="@{/}"/>
+    <attr sel="#hashtag" th:href="@{/posts/search-hashtag}"/>
+</thlogic>


### PR DESCRIPTION
해시태그 검색 페이지로 이동이 쉽도록 헤더에 버튼을 추가했습니다.
해시태그 검색 페이지로 이동하는 버튼 왼편에 게시판으로 이동하는 버튼도 연결해줬습니다.